### PR TITLE
[Bug] fixed issue with frozen timer not reflecting added time until unfrozen

### DIFF
--- a/PixelPainter/States/PlayState.swift
+++ b/PixelPainter/States/PlayState.swift
@@ -35,7 +35,13 @@ class PlayState: GKState {
         SoundManager.shared.playSound(.piecePlaced)
         
         let currentTime = gameScene.context.gameInfo.timeRemaining
-        gameScene.context.gameInfo.timeRemaining = min(10, currentTime + 2)
+        gameScene.context.gameInfo.timeRemaining = currentTime + 2
+        
+        // Force update CircularTimer's display with new time, even when timer is frozen
+        if let timerNode = gameScene.childNode(withName: "//circularTimer") as? CircularTimer {
+            timerNode.updateDiscreteTime(newTimeRemaining: gameScene.context.gameInfo.timeRemaining)
+        }
+        
         hudManager.updateScore()
         bankManager.clearSelection()
         bankManager.refreshBankIfNeeded()


### PR DESCRIPTION
There was an issue where if the timer was frozen and the user placed a piece it didn't reflect the added time until the timer was unfrozen.