### PR TITLE
[Bug] Memorize State image doesnt match PlayState image.

### DIFF
--- a/PixelPainter/States/MemorizeState.swift
+++ b/PixelPainter/States/MemorizeState.swift
@@ -129,7 +129,6 @@ class MemorizeState: GKState {
     }
 
     private func transitionToPlayState() {
-        gameScene.queueManager.moveToNextImage()
         gameScene.queueManager.printCurrentQueue()
         gameScene.context.stateMachine?.enter(PlayState.self)
     }


### PR DESCRIPTION
hotfixed a bug where the MemorizeState image doesn't match with the PlayState.