### PR TITLE
MemorizeSate UI Changes and Game Over Animations

### DIFF
--- a/PixelPainter/Helpers/GridManager.swift
+++ b/PixelPainter/Helpers/GridManager.swift
@@ -118,6 +118,9 @@ class GridManager {
     }
 
     func tryPlacePiece(_ piece: SKSpriteNode, at point: CGPoint) -> Bool {
+        if gameScene?.context.gameInfo.timeRemaining ?? 0 <= 0 {
+            return false
+        }
         guard let gameScene = gameScene,
             let gridNode = gameScene.childNode(withName: "grid")
                 as? SKSpriteNode

--- a/PixelPainter/Helpers/PowerUpManager.swift
+++ b/PixelPainter/Helpers/PowerUpManager.swift
@@ -125,6 +125,10 @@ class PowerUpManager {
     }
 
     private func activatePowerUp(_ type: PowerUpType) {
+        // check if timer isn't 0 before letting player use power-up
+        if gameScene?.context.gameInfo.timeRemaining ?? 0 <= 0 {
+            return
+        }
         // Check power-up has uses remaining
         guard let uses = powerUpUses[type], uses > 0,
               let powerUpIcon = powerUps[type],

--- a/PixelPainter/States/MemorizeState.swift
+++ b/PixelPainter/States/MemorizeState.swift
@@ -116,7 +116,7 @@ class MemorizeState: GKState {
 
         let readyLabel = SKLabelNode(text: "Ready?")
         readyLabel.fontName = "PPNeueMontreal-Bold"
-        readyLabel.fontSize = 40
+        readyLabel.fontSize = 48
         readyLabel.fontColor = .white
         readyLabel.position = CGPoint(
             x: gameScene.size.width / 2, y: gameScene.size.height - 200)
@@ -167,7 +167,7 @@ class MemorizeState: GKState {
 
             let circleNode = SKShapeNode(circleOfRadius: dynamicRadius)
             circleNode.strokeColor = .white
-            circleNode.lineWidth = 4
+            circleNode.lineWidth = 0 // changed to 0 to match current theme
             circleNode.fillColor = UIColor(hex: "252525").withAlphaComponent(
                 0.9)
 
@@ -189,7 +189,7 @@ class MemorizeState: GKState {
             containerNode.addChild(circleNode)
 
             // Animate the reward appearance
-            let fadeIn = SKAction.fadeIn(withDuration: 0.5)
+            let fadeIn = SKAction.fadeIn(withDuration: 0.2)
             let wait = SKAction.wait(forDuration: 0.9)
             containerNode.run(SKAction.sequence([wait, fadeIn]))
         }
@@ -198,8 +198,8 @@ class MemorizeState: GKState {
     private func blinkReadyLabel(readyLabel: SKLabelNode, blinkCount: Int) {
         var remainingBlinks = blinkCount
         
-        let blinkIn = SKAction.fadeIn(withDuration: 0.5)
-        let blinkOut = SKAction.fadeOut(withDuration: 0.5)
+        let blinkIn = SKAction.fadeIn(withDuration: 0.2)
+        let blinkOut = SKAction.fadeOut(withDuration: 0.8)
         let blinkSequence = SKAction.sequence([blinkOut, blinkIn])
 
         let blinkAction = SKAction.run { [weak self] in


### PR DESCRIPTION
Changed MemorizeState UI: grant player power-up icon to match how it looks in playstate (no border). FadeIn animation for reward comes in faster, still experimenting with blinkIn and blinkOut for the Ready Label, which also has size increased.

Added game over animation: Grid shakes, ejects pieces, and switches to game over scene. If there are no pieces on the grid, it just switches to game over without an animation.