### PR TITLE
[Feature/Refactor] Memorize State break apart animation for image, EffectManager into singleton.

### DIFF
--- a/PixelPainter/GameContext.swift
+++ b/PixelPainter/GameContext.swift
@@ -58,7 +58,7 @@ struct LayoutInfo {
         )
     }
 }
-
+	
 struct GameInfo {
     var currentImage: UIImage?
     var pieces: [PuzzlePiece] = []

--- a/PixelPainter/GameScene.swift
+++ b/PixelPainter/GameScene.swift
@@ -21,6 +21,7 @@ class GameScene: SKScene {
         self.context = context
         super.init(size: size)
         SoundManager.shared.setGameScene(self)
+        EffectManager.shared.setGameScene(self)
     }
     
     required init?(coder aDecoder: NSCoder) { fatalError("init(coder:) has not been implemented") }

--- a/PixelPainter/Helpers/PowerUpManager.swift
+++ b/PixelPainter/Helpers/PowerUpManager.swift
@@ -141,7 +141,7 @@ class PowerUpManager {
         case .timeStop:
             if uses > 1 {
                 powerUpsInCooldown.insert(type)
-                playState?.effectManager.cooldown(
+                EffectManager.shared.cooldown(
                     powerUpIcon,
                     duration: GameConstants.PowerUpTimers.timeStopCooldown)
             }
@@ -202,7 +202,7 @@ class PowerUpManager {
         case .flash:
             if uses > 1 {
                 powerUpsInCooldown.insert(type)
-                playState?.effectManager.cooldown(
+                EffectManager.shared.cooldown(
                     powerUpIcon,
                     duration: GameConstants.PowerUpTimers.flashCooldown)
             }
@@ -228,7 +228,7 @@ class PowerUpManager {
         case .shuffle:
             if uses > 1 {
                 powerUpsInCooldown.insert(type)
-                playState?.effectManager.cooldown(powerUpIcon, duration: 0.5)
+                EffectManager.shared.cooldown(powerUpIcon, duration: 0.5)
             }
 
             if let bankManager = playState?.bankManager {

--- a/PixelPainter/States/PlayState.swift
+++ b/PixelPainter/States/PlayState.swift
@@ -14,7 +14,6 @@ class PlayState: GKState {
     let bankManager: BankManager
     let hudManager: HUDManager
     var powerUpManager: PowerUpManager!
-    var effectManager: EffectManager!
 
     private var hintTimer: Timer?
     private var idleHintTimer: Timer?
@@ -24,7 +23,6 @@ class PlayState: GKState {
         self.gridManager = GridManager(gameScene: gameScene)
         self.bankManager = BankManager(gameScene: gameScene)
         self.hudManager = HUDManager(gameScene: gameScene)
-        self.effectManager = EffectManager(gameScene: gameScene)
         super.init()
         self.powerUpManager = PowerUpManager(
             gameScene: gameScene, playState: self)
@@ -143,8 +141,8 @@ class PlayState: GKState {
     }
 
     private func showWrongPlacementAnimation(for piece: SKSpriteNode) {
-        effectManager.disableInteraction()
-        effectManager.shakeNode(piece)
+        EffectManager.shared.disableInteraction()
+        EffectManager.shared.shakeNode(piece)
     }
 
     private func startGame() {
@@ -176,14 +174,14 @@ class PlayState: GKState {
 
                 // Game over check
                 if self.gameScene.context.gameInfo.timeRemaining <= 0 {
-                    self.effectManager.disableInteraction()
+                    EffectManager.shared.disableInteraction()
                     self.stopHintTimer()
                     self.stopIdleHintTimer()
                     
                     if let gridNode = self.gameScene.childNode(withName: "grid") as? SKSpriteNode,
                        !gridNode.children.filter({ $0.name?.starts(with: "piece_") ?? false }).isEmpty {
                         // Only play animation if there are pieces
-                        self.effectManager.playGameOverEffect { [weak self] in
+                        EffectManager.shared.playGameOverEffect { [weak self] in
                             guard let self = self else { return }
                             self.gameScene.context.stateMachine?.enter(GameOverState.self)
                             SoundManager.shared.playSound(.gameOver)


### PR DESCRIPTION
This pull request introduces a **break apart animation for the memorize image** when transitioning into PlayState along with a **refactor of the EffectManager into a Singleton pattern**.

---

## **Key Changes**

### **New Features**
1. **Break Apart Memorize Animation**:
   - Added a visual animation for the picture when transitioning into PlayState (same animation as game over, except no shaking).
---

### **Refactoring**
1. **Refactored EffectManager to Singleton Pattern**:
     - Ensures consistent behavior across the game.
     - Reduces memory usage by avoiding multiple instantiations of the EffectManager.
   - Added static access to `EffectManager.shared` for easier and cleaner integration throughout the codebase.
   - Improved encapsulation and scalability for future effect additions.
---

### **Demo**
#### **Break Apart Memorize Animation**

https://github.com/user-attachments/assets/82a20de4-e52e-41b6-af81-cc9d32010294
